### PR TITLE
[Feat] 캐릭터 직업 정보를 저장하기 위한 Entity를 생성한다.

### DIFF
--- a/src/main/java/maeta/api/domain/occupation/entity/Occupation.java
+++ b/src/main/java/maeta/api/domain/occupation/entity/Occupation.java
@@ -1,0 +1,31 @@
+package maeta.api.domain.occupation.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "OCCUPATION")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Occupation {
+
+    @Id
+    @Column(name = "OCCUPATION_NAME", nullable = false)
+    private OccupationName occupationName;                  // 직업명 (히어로, 다크나이트, 팔라딘)
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "OCCUPATION_CLASS", nullable = false)
+    private OccupationClass occupationClass;                // 소속 (모험가, 시그너스, 레지스탕스)
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "OCCUPATION_TYPE", nullable = false)
+    private OccupationType occupationType;                  // 직업 분류 (전사, 궁수, 마법사)
+
+    public Occupation(OccupationName occupationName, OccupationClass occupationClass, OccupationType occupationType) {
+        this.occupationName = occupationName;
+        this.occupationClass = occupationClass;
+        this.occupationType = occupationType;
+    }
+}

--- a/src/main/java/maeta/api/domain/occupation/entity/OccupationClass.java
+++ b/src/main/java/maeta/api/domain/occupation/entity/OccupationClass.java
@@ -1,0 +1,26 @@
+package maeta.api.domain.occupation.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import maeta.api.global.util.enums.MappableEnum;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum OccupationClass implements MappableEnum {
+    EXPLORER("모험가"),
+    CYGNUS_KNIGHTS("시그너스 기사단"),
+    RESISTANCE("레지스탕스"),
+    HERO("영웅"),
+    NOVA("노바"),
+    FLORA("레프"),
+    TRANSCENDENT("초월자"),
+    ANIMA("아니마"),
+    FRIENDS_WORLD("프렌즈 월드")
+    ;
+
+    private final String occupationClassName; // 소속명
+
+    @Override
+    public String getValue() {
+        return this.occupationClassName;
+    }
+}

--- a/src/main/java/maeta/api/domain/occupation/entity/OccupationName.java
+++ b/src/main/java/maeta/api/domain/occupation/entity/OccupationName.java
@@ -1,0 +1,162 @@
+package maeta.api.domain.occupation.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import maeta.api.global.util.enums.MappableEnum;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum OccupationName implements MappableEnum {
+    // 모험가
+    // 전사
+    HERO("히어로"),
+    PALADIN("팔라딘"),
+    DARK_KNIGHT("다크나이트"),
+
+    // 마법사
+    ARCH_MAGE_FIRE_POISON("아크메이지 (불, 독)"),
+    ARCH_MAGE_ICE_LIGHTNING("아크메이지 (썬, 콜)"),
+    BISHOP("비숍"),
+
+    // 궁수
+    BOW_MASTER("보우마스터"),
+    MARKSMAN("신궁"),
+    PATH_FINDER("패스파인더"),
+
+    // 도적
+    NIGHT_LORD("나이트로드"),
+    SHADOWER("섀도어"),
+    DUAL_BLADE("듀얼블레이드"),
+
+    // 해적
+    VIPER("바이퍼"),
+    CAPTAIN("캡틴"),
+    CANNON_SHOOTER("캐논슈터"),
+
+    // 시그너스 기사단
+    // 전사
+    SOUL_MASTER("소울마스터"),
+    MIHILE("미하일"),
+
+    // 마법사
+    FLAME_WIZARD("플레임위자드"),
+
+    // 궁수
+    WIND_BREAKER("윈드브레이커"),
+
+    // 도적
+    NIGHT_WALKER("나이트워커"),
+
+    // 해적
+    STRIKER("스트라이커"),
+
+    // 레지스탕스
+    // 전사
+    BLASTER("블래스터"),
+    DEMON_SLAYER("데몬슬레이어"),
+    DEMON_AVENGER("데몬어벤저"),
+
+    // 마법사
+    BATTLE_MAGE("배틀메이지"),
+
+    // 궁수
+    WILD_HUNTER("와일드헌터"),
+
+    // 도적
+    XENON("제논"),
+
+    // 해적
+    MECHANIC("메카닉"),
+
+    // 영웅
+    // 전사
+    ARAN("아란"),
+
+    // 마법사
+    EVAN("에반"),
+    LUMINOUS("루미너스"),
+
+    // 궁수
+    MERCEDES("메르세데스"),
+
+    // 도적
+    PHANTOM("팬텀"),
+
+    // 해적
+    EUNWOL("은월"),
+
+    // 노바
+    // 전사
+    KAISER("카이저"),
+
+    // 마법사
+
+    // 궁수
+
+    // 도적
+    CADENA("카데나"),
+
+    // 해적
+    ANGELIC_BUSTER("엔젤릭버스터"),
+
+    // 레프
+    // 전사
+    ADELE("아델"),
+
+    // 마법사
+    ILLIUM("일리움"),
+
+    // 궁수
+    KAIN("카인"),
+
+    // 도적
+    KHALI("칼리"),
+
+    // 해적
+    ARK("아크"),
+
+    // 초월자
+    // 전사
+    ZERO("제로"),
+
+    // 마법사
+
+    // 궁수
+
+    // 도적
+
+    // 해적
+
+    // 아니마
+    // 전사
+    REN("렌"),
+
+    // 마법사
+    LARA("라라"),
+
+    // 궁수
+
+    // 도적
+    HOYOUNG("호영"),
+
+    // 해적
+
+    // 프렌즈 월드
+    // 전사
+
+    // 마법사
+    KINESIS("키네시스")
+
+    // 궁수
+
+    // 도적
+
+    // 해적
+    ;
+
+    private final String occupationName;
+
+    @Override
+    public String getValue() {
+        return this.occupationName;
+    }
+}

--- a/src/main/java/maeta/api/domain/occupation/entity/OccupationType.java
+++ b/src/main/java/maeta/api/domain/occupation/entity/OccupationType.java
@@ -1,0 +1,22 @@
+package maeta.api.domain.occupation.entity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import maeta.api.global.util.enums.MappableEnum;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum OccupationType implements MappableEnum {
+    WARRIOR("전사"),
+    MAGICIAN("마법사"),
+    BOWMAN("궁수"),
+    THIEF("도적"),
+    PIRATE("해적")
+    ;
+
+    private final String occupationType; // 직업 분류
+
+    @Override
+    public String getValue() {
+        return this.occupationType;
+    }
+}

--- a/src/main/java/maeta/api/global/util/OccupationUtil.java
+++ b/src/main/java/maeta/api/global/util/OccupationUtil.java
@@ -1,0 +1,27 @@
+package maeta.api.global.util;
+
+import lombok.experimental.UtilityClass;
+import maeta.api.domain.occupation.entity.OccupationClass;
+import maeta.api.domain.occupation.entity.OccupationName;
+import maeta.api.domain.occupation.entity.OccupationType;
+
+import static maeta.api.global.util.enums.EnumUtil.*;
+
+@UtilityClass
+public class OccupationUtil {
+
+    // 직업계층 정보를 Enum 클래스로 변환한다.
+    public OccupationClass convertToOccupationClass(String occupationClass) {
+        return convertValue(occupationClass, OccupationClass.values());
+    }
+
+    // 직업군 정보를 Enum 클래스로 변환한다.
+    public OccupationType convertToOccupationType(String occupationType) {
+        return convertValue(occupationType, OccupationType.values());
+    }
+
+    // 직업명을 Enum 클래스로 변환한다.
+    public OccupationName convertToOccupationName(String occupationName) {
+        return convertValue(occupationName, OccupationName.values());
+    }
+}

--- a/src/main/java/maeta/api/global/util/enums/EnumUtil.java
+++ b/src/main/java/maeta/api/global/util/enums/EnumUtil.java
@@ -1,0 +1,17 @@
+package maeta.api.global.util.enums;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.Arrays;
+
+@UtilityClass
+public class EnumUtil {
+
+    // Enum 클래스에 선언되어 있는 값 중, key 값과 일치하는 정보 반환
+    public <T extends Enum<T> & MappableEnum> T convertValue(String key, T[] enumInfoArr) {
+        return Arrays.stream(enumInfoArr)
+                        .filter(info -> key.equals(info.getValue()))
+                        .findFirst()
+                        .orElseThrow();
+    }
+}

--- a/src/main/java/maeta/api/global/util/enums/MappableEnum.java
+++ b/src/main/java/maeta/api/global/util/enums/MappableEnum.java
@@ -1,0 +1,5 @@
+package maeta.api.global.util.enums;
+
+public interface MappableEnum {
+    String getValue();
+}

--- a/src/test/java/maeta/api/global/factory/util/enums/EnumUtilFactory.java
+++ b/src/test/java/maeta/api/global/factory/util/enums/EnumUtilFactory.java
@@ -1,0 +1,39 @@
+package maeta.api.global.factory.util.enums;
+
+import maeta.api.domain.occupation.entity.OccupationClass;
+import maeta.api.domain.occupation.entity.OccupationName;
+import maeta.api.domain.occupation.entity.OccupationType;
+import maeta.api.global.util.enums.MappableEnum;
+
+import static maeta.api.domain.occupation.entity.OccupationClass.*;
+import static maeta.api.domain.occupation.entity.OccupationName.*;
+import static maeta.api.domain.occupation.entity.OccupationType.*;
+
+public enum EnumUtilFactory {
+    // 실패 테스트
+    FAILURE_TEST_CASE_1("FAILURE_VALUE1", OccupationClass.values()),
+    FAILURE_TEST_CASE_2("FAILURE_VALUE2", OccupationName.values()),
+    FAILURE_TEST_CASE_3("FAILURE_VALUE3", OccupationType.values()),
+
+    // 성공 테스트
+    SUCCESS_TEST_CASE_1(EXPLORER.getValue(), OccupationClass.values()),
+    SUCCESS_TEST_CASE_2(DUAL_BLADE.getValue(), OccupationName.values()),
+    SUCCESS_TEST_CASE_3(THIEF.getValue(), OccupationType.values())
+    ;
+
+    private final String value;
+    private final MappableEnum[] mappableEnum;
+
+    EnumUtilFactory(String value, MappableEnum[] mappableEnum) {
+        this.value = value;
+        this.mappableEnum = mappableEnum;
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    public MappableEnum[] getMappableEnum() {
+        return this.mappableEnum;
+    }
+}

--- a/src/test/java/maeta/api/global/util/EnumUtilTest.java
+++ b/src/test/java/maeta/api/global/util/EnumUtilTest.java
@@ -1,0 +1,50 @@
+package maeta.api.global.util;
+
+import maeta.api.domain.occupation.entity.OccupationClass;
+import maeta.api.global.factory.util.enums.EnumUtilFactory;
+import maeta.api.global.util.enums.EnumUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.NoSuchElementException;
+
+import static maeta.api.global.factory.util.enums.EnumUtilFactory.FAILURE_TEST_CASE_1;
+import static maeta.api.global.factory.util.enums.EnumUtilFactory.SUCCESS_TEST_CASE_1;
+
+@DisplayName("[Utility Class Test :: EnumUtil]")
+public class EnumUtilTest {
+
+    @Nested
+    @DisplayName("EnumUtil.convertValue() 메서드를 테스트한다.")
+    public class convertValueTest {
+
+        @Test
+        @DisplayName("존재하지 않는 코드 값을 통하여 메서드를 호출하는 경우, 오류가 발생한다.")
+        public void failure() {
+            // given
+            EnumUtilFactory failureCase = FAILURE_TEST_CASE_1;
+            String key = failureCase.getValue();
+            OccupationClass[] values = (OccupationClass[]) failureCase.getMappableEnum();
+
+            // when - then
+            Assertions.assertThrows(NoSuchElementException.class, () -> EnumUtil.convertValue(key, values));
+        }
+
+        @Test
+        @DisplayName("메서드 호출에 성공한다.")
+        public void success() {
+            // given
+            EnumUtilFactory successCase = SUCCESS_TEST_CASE_1;
+            String key = successCase.getValue();
+            OccupationClass[] values = (OccupationClass[]) successCase.getMappableEnum();
+
+            // when
+            OccupationClass occupationClass = EnumUtil.convertValue(key, values);
+
+            // then
+            org.assertj.core.api.Assertions.assertThat(occupationClass.getValue()).isEqualTo(key);
+        }
+    }
+}

--- a/src/test/java/maeta/api/global/util/OccupationUtilTest.java
+++ b/src/test/java/maeta/api/global/util/OccupationUtilTest.java
@@ -1,0 +1,109 @@
+package maeta.api.global.util;
+
+import maeta.api.domain.occupation.entity.OccupationClass;
+import maeta.api.domain.occupation.entity.OccupationName;
+import maeta.api.domain.occupation.entity.OccupationType;
+import maeta.api.global.factory.util.enums.EnumUtilFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.NoSuchElementException;
+
+import static maeta.api.global.util.OccupationUtil.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("[Utility Class Test :: OccupationUtil]")
+public class OccupationUtilTest {
+
+    @Nested
+    @DisplayName("OccupationUtil.convertToOccupationClass() 메서드를 테스트한다.")
+    public class convertToOccupationClassTest {
+
+        @Test
+        @DisplayName("존재하지 않는 코드 값을 통하여 메서드를 호출하는 경우, 오류가 발생한다.")
+        public void failure() {
+            // given
+            EnumUtilFactory failureCase = EnumUtilFactory.FAILURE_TEST_CASE_1;
+            String key = failureCase.getValue();
+
+            // when - then
+            assertThrows(NoSuchElementException.class, () -> convertToOccupationClass(key));
+        }
+
+        @Test
+        @DisplayName("OccupationClass 정보 조회에 성공한다.")
+        public void success() {
+            // given
+            EnumUtilFactory successCase = EnumUtilFactory.SUCCESS_TEST_CASE_1;
+            String key = successCase.getValue();
+
+            // when
+            OccupationClass occupationClass = convertToOccupationClass(key);
+
+            // then
+            assertThat(occupationClass.getValue()).isEqualTo(key);
+        }
+    }
+
+    @Nested
+    @DisplayName("OccupationUtil.convertToOccupationName() 메서드를 테스트한다.")
+    public class convertToOccupationNameTest {
+
+        @Test
+        @DisplayName("존재하지 않는 코드 값을 통하여 메서드를 호출하는 경우, 오류가 발생한다.")
+        public void failure() {
+            // given
+            EnumUtilFactory failureCase = EnumUtilFactory.FAILURE_TEST_CASE_2;
+            String key = failureCase.getValue();
+
+            // when - then
+            assertThrows(NoSuchElementException.class, () -> convertToOccupationName(key));
+        }
+
+        @Test
+        @DisplayName("OccupationName 정보 조회에 성공한다.")
+        public void success() {
+            // given
+            EnumUtilFactory successCase = EnumUtilFactory.SUCCESS_TEST_CASE_2;
+            String key = successCase.getValue();
+
+            // when
+            OccupationName occupationName = convertToOccupationName(key);
+
+            // then
+            assertThat(occupationName.getValue()).isEqualTo(key);
+        }
+    }
+
+    @Nested
+    @DisplayName("OccupationUtil.convertToOccupationType() 메서드를 테스트한다.")
+    public class convertToOccupationTypeTest {
+
+        @Test
+        @DisplayName("존재하지 않는 코드 값을 통하여 메서드를 호출하는 경우, 오류가 발생한다.")
+        public void failure() {
+            // given
+            EnumUtilFactory failureCase = EnumUtilFactory.FAILURE_TEST_CASE_3;
+            String key = failureCase.getValue();
+
+            // when - then
+            assertThrows(NoSuchElementException.class, () -> convertToOccupationType(key));
+        }
+
+        @Test
+        @DisplayName("OccupationType 정보 조회에 성공한다.")
+        public void success() {
+            // given
+            EnumUtilFactory successCase = EnumUtilFactory.SUCCESS_TEST_CASE_3;
+            String key = successCase.getValue();
+
+            // when
+            OccupationType occupationType = convertToOccupationType(key);
+
+            // then
+            assertThat(occupationType.getValue()).isEqualTo(key);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
 - Occupation Entity 생성
 - OccupationClass Enum 클래스 생성
 - OccupationName Enum 클래스 생성
 - OccupationType Enum 클래스 생성
 - 로직 관련 Util 클래스 추가 (EnumUtil, OccupationUil)

## Opinions
- 캐릭터 직업 정보를 저장하기 위한 Occupation Entity를 생성 완료하였습니다.
  Entity 이름으로 Job이나 Class를 사용하고 싶었으나, Java 혹은 Spring 진영에서 자주 사용되는 키워드기에 Entity 이름을 다음처럼 설정하였습니다.
- OccupationClass 클래스는 직업별 소속을 저장하기 위한 Enum 클래스입니다.
- OccupationName 클래스는 직업의 이름을 저장하기 위한 Enum 클래스입니다.
- OccupationType 클래스는 직업 분류를 저장하기 위한 Enum 클래스입니다.

## Issue Number And Link
closes #1 